### PR TITLE
Standardize order of checks

### DIFF
--- a/lib/struct.ex
+++ b/lib/struct.ex
@@ -40,15 +40,6 @@ defmodule Bliss.Struct do
 
         def __bliss__(:fields), do: unquote(fields)
 
-        def check(result, rules, context) do
-          result
-          |> check(:conversions, rules, context)
-          |> check(:type, rules, context)
-          |> check(:mutations, rules, context)
-          |> check(:assertions, rules, context)
-          |> check(:fields, rules, context)
-        end
-
         def check(result, :conversions, rules, context) do
           result
           |> Bliss.Any.check(:conversions, rules, context)
@@ -63,6 +54,7 @@ defmodule Bliss.Struct do
         def check(result, :assertions, rules, context) do
           result
           |> Bliss.Any.check(:assertions, rules, context)
+          |> check(:fields, rules, context)
         end
 
         def check(result, _rule, _options, _context) when result.value == nil do

--- a/lib/struct.ex
+++ b/lib/struct.ex
@@ -42,10 +42,27 @@ defmodule Bliss.Struct do
 
         def check(result, rules, context) do
           result
-          |> Bliss.Any.check(rules, context)
-          |> maybe_check(:cast, rules, context)
+          |> check(:conversions, rules, context)
           |> check(:type, rules, context)
+          |> check(:mutations, rules, context)
+          |> check(:assertions, rules, context)
           |> check(:fields, rules, context)
+        end
+
+        def check(result, :conversions, rules, context) do
+          result
+          |> Bliss.Any.check(:conversions, rules, context)
+          |> maybe_check(:cast, rules, context)
+        end
+
+        def check(result, :mutations, rules, context) do
+          result
+          |> Bliss.Any.check(:mutations, rules, context)
+        end
+
+        def check(result, :assertions, rules, context) do
+          result
+          |> Bliss.Any.check(:assertions, rules, context)
         end
 
         def check(result, _rule, _options, _context) when result.value == nil do

--- a/lib/type.ex
+++ b/lib/type.ex
@@ -16,6 +16,14 @@ defmodule Bliss.Type do
         |> Bliss.Result.to_tuple()
       end
 
+      def check(result, rules, context) do
+        result
+        |> check(:conversions, rules, context)
+        |> check(:type, rules, context)
+        |> check(:mutations, rules, context)
+        |> check(:assertions, rules, context)
+      end
+
       def maybe_check(result, rule, rules, context) do
         if Keyword.has_key?(rules, rule) do
           check(result, rule, Keyword.fetch!(rules, rule), context)
@@ -46,7 +54,6 @@ defmodule Bliss.Type do
   @typedoc "Custom types are represented by user-defined modules."
   @type custom :: module
 
-  @callback check(Bliss.Result.t(), any, Bliss.Context.t()) :: Bliss.Result.t()
   @callback check(Bliss.Result.t(), atom, any, Bliss.Context.t()) :: Bliss.Result.t()
 
   @base_types %{

--- a/lib/types/any.ex
+++ b/lib/types/any.ex
@@ -3,13 +3,6 @@ defmodule Bliss.Any do
 
   use Bliss.Type, options: [:default, :required, :equals, :enum]
 
-  def check(result, rules, context) do
-    result
-    |> check(:conversions, rules, context)
-    |> check(:mutations, rules, context)
-    |> check(:assertions, rules, context)
-  end
-
   def check(result, :conversions, rules, context) do
     result
     |> maybe_check(:default, rules, context)
@@ -31,6 +24,10 @@ defmodule Bliss.Any do
   end
 
   def check(result, :default, _value, _context) do
+    result
+  end
+
+  def check(result, :type, _options, _context) do
     result
   end
 

--- a/lib/types/any.ex
+++ b/lib/types/any.ex
@@ -5,7 +5,22 @@ defmodule Bliss.Any do
 
   def check(result, rules, context) do
     result
+    |> check(:conversions, rules, context)
+    |> check(:mutations, rules, context)
+    |> check(:assertions, rules, context)
+  end
+
+  def check(result, :conversions, rules, context) do
+    result
     |> maybe_check(:default, rules, context)
+  end
+
+  def check(result, :mutations, _rules, _context) do
+    result
+  end
+
+  def check(result, :assertions, rules, context) do
+    result
     |> maybe_check(:required, rules, context)
     |> maybe_check(:equals, rules, context)
     |> maybe_check(:enum, rules, context)

--- a/lib/types/atom.ex
+++ b/lib/types/atom.ex
@@ -4,14 +4,6 @@ defmodule Bliss.Atom do
   use Bliss.Type,
     options: Bliss.Any.__bliss__(:options) ++ [:parse]
 
-  def check(result, rules, context) do
-    result
-    |> check(:conversions, rules, context)
-    |> check(:type, rules, context)
-    |> check(:mutations, rules, context)
-    |> check(:assertions, rules, context)
-  end
-
   def check(result, :conversions, rules, context) do
     result
     |> Any.check(:conversions, rules, context)

--- a/lib/types/atom.ex
+++ b/lib/types/atom.ex
@@ -6,9 +6,26 @@ defmodule Bliss.Atom do
 
   def check(result, rules, context) do
     result
-    |> Any.check(rules, context)
-    |> maybe_check(:parse, rules, context)
+    |> check(:conversions, rules, context)
     |> check(:type, rules, context)
+    |> check(:mutations, rules, context)
+    |> check(:assertions, rules, context)
+  end
+
+  def check(result, :conversions, rules, context) do
+    result
+    |> Any.check(:conversions, rules, context)
+    |> maybe_check(:parse, rules, context)
+  end
+
+  def check(result, :mutations, rules, context) do
+    result
+    |> Any.check(:mutations, rules, context)
+  end
+
+  def check(result, :assertions, rules, context) do
+    result
+    |> Any.check(:assertions, rules, context)
   end
 
   def check(result, _rule, _options, _context) when result.value == nil do

--- a/lib/types/boolean.ex
+++ b/lib/types/boolean.ex
@@ -6,9 +6,26 @@ defmodule Bliss.Boolean do
 
   def check(result, rules, context) do
     result
-    |> Any.check(rules, context)
-    |> maybe_check(:parse, rules, context)
+    |> check(:conversions, rules, context)
     |> check(:type, rules, context)
+    |> check(:mutations, rules, context)
+    |> check(:assertions, rules, context)
+  end
+
+  def check(result, :conversions, rules, context) do
+    result
+    |> Any.check(:conversions, rules, context)
+    |> maybe_check(:parse, rules, context)
+  end
+
+  def check(result, :mutations, rules, context) do
+    result
+    |> Any.check(:mutations, rules, context)
+  end
+
+  def check(result, :assertions, rules, context) do
+    result
+    |> Any.check(:assertions, rules, context)
   end
 
   def check(result, _rule, _options, _context) when result.value == nil do

--- a/lib/types/boolean.ex
+++ b/lib/types/boolean.ex
@@ -4,14 +4,6 @@ defmodule Bliss.Boolean do
   use Bliss.Type,
     options: Bliss.Any.__bliss__(:options) ++ [:parse]
 
-  def check(result, rules, context) do
-    result
-    |> check(:conversions, rules, context)
-    |> check(:type, rules, context)
-    |> check(:mutations, rules, context)
-    |> check(:assertions, rules, context)
-  end
-
   def check(result, :conversions, rules, context) do
     result
     |> Any.check(:conversions, rules, context)

--- a/lib/types/date.ex
+++ b/lib/types/date.ex
@@ -6,10 +6,27 @@ defmodule Bliss.Date do
 
   def check(result, rules, context) do
     result
-    |> Any.check(rules, context)
+    |> check(:conversions, rules, context)
+    |> check(:type, rules, context)
+    |> check(:mutations, rules, context)
+    |> check(:assertions, rules, context)
+  end
+
+  def check(result, :conversions, rules, context) do
+    result
+    |> Any.check(:conversions, rules, context)
     |> maybe_check(:parse, rules, context)
     |> maybe_check(:trunc, rules, context)
-    |> check(:type, rules, context)
+  end
+
+  def check(result, :mutations, rules, context) do
+    result
+    |> Any.check(:mutations, rules, context)
+  end
+
+  def check(result, :assertions, rules, context) do
+    result
+    |> Any.check(:assertions, rules, context)
     |> maybe_check(:min, rules, context)
     |> maybe_check(:max, rules, context)
   end

--- a/lib/types/date.ex
+++ b/lib/types/date.ex
@@ -4,14 +4,6 @@ defmodule Bliss.Date do
   use Bliss.Type,
     options: Bliss.Any.__bliss__(:options) ++ [:parse, :trunc, :min, :max]
 
-  def check(result, rules, context) do
-    result
-    |> check(:conversions, rules, context)
-    |> check(:type, rules, context)
-    |> check(:mutations, rules, context)
-    |> check(:assertions, rules, context)
-  end
-
   def check(result, :conversions, rules, context) do
     result
     |> Any.check(:conversions, rules, context)

--- a/lib/types/date_time.ex
+++ b/lib/types/date_time.ex
@@ -4,14 +4,6 @@ defmodule Bliss.DateTime do
   use Bliss.Type,
     options: Bliss.Any.__bliss__(:options) ++ [:parse, :allow_int, :shift, :trunc, :min, :max]
 
-  def check(result, rules, context) do
-    result
-    |> check(:conversions, rules, context)
-    |> check(:type, rules, context)
-    |> check(:mutations, rules, context)
-    |> check(:assertions, rules, context)
-  end
-
   def check(result, :conversions, rules, context) do
     result
     |> Any.check(:conversions, rules, context)

--- a/lib/types/date_time.ex
+++ b/lib/types/date_time.ex
@@ -6,12 +6,29 @@ defmodule Bliss.DateTime do
 
   def check(result, rules, context) do
     result
-    |> Any.check(rules, context)
+    |> check(:conversions, rules, context)
+    |> check(:type, rules, context)
+    |> check(:mutations, rules, context)
+    |> check(:assertions, rules, context)
+  end
+
+  def check(result, :conversions, rules, context) do
+    result
+    |> Any.check(:conversions, rules, context)
     |> maybe_check(:parse, rules, context)
     |> maybe_check(:allow_int, rules, context)
-    |> check(:type, rules, context)
+  end
+
+  def check(result, :mutations, rules, context) do
+    result
+    |> Any.check(:mutations, rules, context)
     |> maybe_check(:shift, rules, context)
     |> maybe_check(:trunc, rules, context)
+  end
+
+  def check(result, :assertions, rules, context) do
+    result
+    |> Any.check(:assertions, rules, context)
     |> maybe_check(:min, rules, context)
     |> maybe_check(:max, rules, context)
   end

--- a/lib/types/float.ex
+++ b/lib/types/float.ex
@@ -5,14 +5,6 @@ defmodule Bliss.Float do
     options:
       Bliss.Any.__bliss__(:options) ++ [:parse, :allow_int, :min, :max, :greater_than, :less_than]
 
-  def check(result, rules, context) do
-    result
-    |> check(:conversions, rules, context)
-    |> check(:type, rules, context)
-    |> check(:mutations, rules, context)
-    |> check(:assertions, rules, context)
-  end
-
   def check(result, :conversions, rules, context) do
     result
     |> Any.check(:conversions, rules, context)

--- a/lib/types/float.ex
+++ b/lib/types/float.ex
@@ -7,10 +7,27 @@ defmodule Bliss.Float do
 
   def check(result, rules, context) do
     result
-    |> Any.check(rules, context)
+    |> check(:conversions, rules, context)
+    |> check(:type, rules, context)
+    |> check(:mutations, rules, context)
+    |> check(:assertions, rules, context)
+  end
+
+  def check(result, :conversions, rules, context) do
+    result
+    |> Any.check(:conversions, rules, context)
     |> maybe_check(:parse, rules, context)
     |> maybe_check(:allow_int, rules, context)
-    |> check(:type, rules, context)
+  end
+
+  def check(result, :mutations, rules, context) do
+    result
+    |> Any.check(:mutations, rules, context)
+  end
+
+  def check(result, :assertions, rules, context) do
+    result
+    |> Any.check(:assertions, rules, context)
     |> maybe_check(:min, rules, context)
     |> maybe_check(:max, rules, context)
     |> maybe_check(:greater_than, rules, context)

--- a/lib/types/integer.ex
+++ b/lib/types/integer.ex
@@ -5,14 +5,6 @@ defmodule Bliss.Integer do
     options:
       Bliss.Any.__bliss__(:options) ++ [:parse, :trunc, :min, :max, :greater_than, :less_than]
 
-  def check(result, rules, context) do
-    result
-    |> check(:conversions, rules, context)
-    |> check(:type, rules, context)
-    |> check(:mutations, rules, context)
-    |> check(:assertions, rules, context)
-  end
-
   def check(result, :conversions, rules, context) do
     result
     |> Any.check(:conversions, rules, context)

--- a/lib/types/integer.ex
+++ b/lib/types/integer.ex
@@ -7,10 +7,27 @@ defmodule Bliss.Integer do
 
   def check(result, rules, context) do
     result
-    |> Any.check(rules, context)
+    |> check(:conversions, rules, context)
+    |> check(:type, rules, context)
+    |> check(:mutations, rules, context)
+    |> check(:assertions, rules, context)
+  end
+
+  def check(result, :conversions, rules, context) do
+    result
+    |> Any.check(:conversions, rules, context)
     |> maybe_check(:parse, rules, context)
     |> maybe_check(:trunc, rules, context)
-    |> check(:type, rules, context)
+  end
+
+  def check(result, :mutations, rules, context) do
+    result
+    |> Any.check(:mutations, rules, context)
+  end
+
+  def check(result, :assertions, rules, context) do
+    result
+    |> Any.check(:assertions, rules, context)
     |> maybe_check(:min, rules, context)
     |> maybe_check(:max, rules, context)
     |> maybe_check(:greater_than, rules, context)

--- a/lib/types/list.ex
+++ b/lib/types/list.ex
@@ -4,14 +4,6 @@ defmodule Bliss.List do
   use Bliss.Type,
     options: Bliss.Any.__bliss__(:options) ++ [:length, :min, :max, :items]
 
-  def check(result, rules, context) do
-    result
-    |> check(:conversions, rules, context)
-    |> check(:type, rules, context)
-    |> check(:mutations, rules, context)
-    |> check(:assertions, rules, context)
-  end
-
   def check(result, :conversions, rules, context) do
     result
     |> Any.check(:conversions, rules, context)

--- a/lib/types/list.ex
+++ b/lib/types/list.ex
@@ -6,8 +6,25 @@ defmodule Bliss.List do
 
   def check(result, rules, context) do
     result
-    |> Any.check(rules, context)
+    |> check(:conversions, rules, context)
     |> check(:type, rules, context)
+    |> check(:mutations, rules, context)
+    |> check(:assertions, rules, context)
+  end
+
+  def check(result, :conversions, rules, context) do
+    result
+    |> Any.check(:conversions, rules, context)
+  end
+
+  def check(result, :mutations, rules, context) do
+    result
+    |> Any.check(:mutations, rules, context)
+  end
+
+  def check(result, :assertions, rules, context) do
+    result
+    |> Any.check(:assertions, rules, context)
     |> maybe_check(:length, rules, context)
     |> maybe_check(:min, rules, context)
     |> maybe_check(:max, rules, context)

--- a/lib/types/map.ex
+++ b/lib/types/map.ex
@@ -6,9 +6,26 @@ defmodule Bliss.Map do
 
   def check(result, rules, context) do
     result
-    |> Any.check(rules, context)
+    |> check(:conversions, rules, context)
     |> check(:type, rules, context)
+    |> check(:mutations, rules, context)
+    |> check(:assertions, rules, context)
+  end
+
+  def check(result, :conversions, rules, context) do
+    result
+    |> Any.check(:conversions, rules, context)
+  end
+
+  def check(result, :mutations, rules, context) do
+    result
+    |> Any.check(:mutations, rules, context)
     |> maybe_check(:atomize_keys, rules, context)
+  end
+
+  def check(result, :assertions, rules, context) do
+    result
+    |> Any.check(:assertions, rules, context)
     |> maybe_check(:size, rules, context)
     |> maybe_check(:min, rules, context)
     |> maybe_check(:max, rules, context)

--- a/lib/types/map.ex
+++ b/lib/types/map.ex
@@ -4,14 +4,6 @@ defmodule Bliss.Map do
   use Bliss.Type,
     options: Bliss.Any.__bliss__(:options) ++ [:atomize_keys, :size, :min, :max]
 
-  def check(result, rules, context) do
-    result
-    |> check(:conversions, rules, context)
-    |> check(:type, rules, context)
-    |> check(:mutations, rules, context)
-    |> check(:assertions, rules, context)
-  end
-
   def check(result, :conversions, rules, context) do
     result
     |> Any.check(:conversions, rules, context)

--- a/lib/types/string.ex
+++ b/lib/types/string.ex
@@ -3,14 +3,6 @@ defmodule Bliss.String do
 
   use Bliss.Type, options: Bliss.Any.__bliss__(:options) ++ [:trim, :length]
 
-  def check(result, rules, context) do
-    result
-    |> check(:conversions, rules, context)
-    |> check(:type, rules, context)
-    |> check(:mutations, rules, context)
-    |> check(:assertions, rules, context)
-  end
-
   def check(result, :conversions, rules, context) do
     result
     |> Any.check(:conversions, rules, context)

--- a/lib/types/string.ex
+++ b/lib/types/string.ex
@@ -5,9 +5,26 @@ defmodule Bliss.String do
 
   def check(result, rules, context) do
     result
-    |> Any.check(rules, context)
+    |> check(:conversions, rules, context)
     |> check(:type, rules, context)
+    |> check(:mutations, rules, context)
+    |> check(:assertions, rules, context)
+  end
+
+  def check(result, :conversions, rules, context) do
+    result
+    |> Any.check(:conversions, rules, context)
+  end
+
+  def check(result, :mutations, rules, context) do
+    result
+    |> Any.check(:mutations, rules, context)
     |> maybe_check(:trim, rules, context)
+  end
+
+  def check(result, :assertions, rules, context) do
+    result
+    |> Any.check(:assertions, rules, context)
     |> maybe_check(:length, rules, context)
   end
 

--- a/lib/types/time.ex
+++ b/lib/types/time.ex
@@ -4,14 +4,6 @@ defmodule Bliss.Time do
   use Bliss.Type,
     options: Bliss.Any.__bliss__(:options) ++ [:parse, :trunc, :min, :max]
 
-  def check(result, rules, context) do
-    result
-    |> check(:conversions, rules, context)
-    |> check(:type, rules, context)
-    |> check(:mutations, rules, context)
-    |> check(:assertions, rules, context)
-  end
-
   def check(result, :conversions, rules, context) do
     result
     |> Any.check(:conversions, rules, context)

--- a/lib/types/time.ex
+++ b/lib/types/time.ex
@@ -6,10 +6,27 @@ defmodule Bliss.Time do
 
   def check(result, rules, context) do
     result
-    |> Any.check(rules, context)
-    |> maybe_check(:parse, rules, context)
+    |> check(:conversions, rules, context)
     |> check(:type, rules, context)
+    |> check(:mutations, rules, context)
+    |> check(:assertions, rules, context)
+  end
+
+  def check(result, :conversions, rules, context) do
+    result
+    |> Any.check(:conversions, rules, context)
+    |> maybe_check(:parse, rules, context)
+  end
+
+  def check(result, :mutations, rules, context) do
+    result
+    |> Any.check(:mutations, rules, context)
     |> maybe_check(:trunc, rules, context)
+  end
+
+  def check(result, :assertions, rules, context) do
+    result
+    |> Any.check(:assertions, rules, context)
     |> maybe_check(:min, rules, context)
     |> maybe_check(:max, rules, context)
   end


### PR DESCRIPTION
1. `:conversions` - convert the input type
2. `:type` - assert the input type
3. `:mutations` - update the input value
4. `:assertions` - assert the input value